### PR TITLE
Support kitchen destroy

### DIFF
--- a/lib/guard/kitchen.rb
+++ b/lib/guard/kitchen.rb
@@ -36,21 +36,18 @@ module Guard
     end
 
     def stop
-      ::Guard::UI.warning("Guard::Kitchen cannot stop for you, due to strange bug.")
-      ::Guard::UI.warning("You likely want to run 'kitchen destroy'")
-      #::Guard::UI.info("Guard::Kitchen is stopping")
-      #cmd = Mixlib::ShellOut.new("kitchen destroy")
-      #cmd.live_stream = STDOUT
-      #cmd.run_command
-      #begin
-      #  cmd.error!
-      #rescue Mixlib::ShellOut::ShellCommandFailed => e
-      #  ::Guard::UI.info("Kitchen failed with #{e.to_s}")
-      #  throw :task_has_failed
-      #ensure
-      #  # Sometimes, we leave the occasional shell process unreaped!
-      #  Process.waitall
-      #end
+      ::Guard::UI.info("Guard::Kitchen is stopping")
+      cmd = Mixlib::ShellOut.new("kitchen destroy", :timeout => 10800)
+      cmd.live_stream = STDOUT
+      cmd.run_command
+      begin
+       cmd.error!
+       Notifier.notify('Kitchen destroyed', :title => 'test-kitchen', :image => :success)
+      rescue Mixlib::ShellOut::ShellCommandFailed => e
+        Notifier.notify('Kitchen destroy failed', :title => 'test-kitchen', :image => :failed)
+       ::Guard::UI.info("Kitchen failed with #{e.to_s}")
+       throw :task_has_failed
+      end
     end
 
     def reload

--- a/lib/guard/kitchen/version.rb
+++ b/lib/guard/kitchen/version.rb
@@ -3,6 +3,6 @@ require 'guard/guard'
 
 module Guard
   class Kitchen < Guard
-    VERSION = "0.0.2"
+    VERSION = "0.0.3"
   end
 end


### PR DESCRIPTION
This PR is for supporting executing `kitchen destroy` on the `stop` hook.

The first commit, brings the rspec unit tests to a workable state.  The second commit is the actual change to support shelling out to execute `kitchen destroy`.  I am not sure what the initial bug that was referred to in the comments, but running `guard` with these changes appears to work just fine.
