### PR TITLE
made changes to reflect a deprecation notice from Guard. See @url https:...

### DIFF
--- a/lib/guard/kitchen.rb
+++ b/lib/guard/kitchen.rb
@@ -15,11 +15,11 @@
 #
 
 require "guard"
-require "guard/guard"
+require "guard/plugin"
 require "mixlib/shellout"
 
 module Guard
-  class Kitchen < Guard
+  class Kitchen < Plugin
     def start
       ::Guard::UI.info("Guard::Kitchen is starting")
       cmd = Mixlib::ShellOut.new("kitchen create", :timeout => 10800)

--- a/lib/guard/kitchen/version.rb
+++ b/lib/guard/kitchen/version.rb
@@ -1,8 +1,8 @@
 require 'guard'
-require 'guard/guard'
+require 'guard/plugin'
 
 module Guard
-  class Kitchen < Guard
-    VERSION = "0.0.3"
+  class Kitchen < Plugin
+    VERSION = "0.0.4"
   end
 end


### PR DESCRIPTION
The latest version of Guard throws a pretty intense warning about some deprecated code being called. Fortunately it also tells you what you need to do to fix it in a very easy manner.  See @url https://github.com/guard/guard/wiki/Upgrading-to-Guard-2.0#changes-in-guardguard
