### PR TITLE
Compatibility with guard v2.x

### DIFF
--- a/guard-kitchen.gemspec
+++ b/guard-kitchen.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "guard"
+  spec.add_dependency "guard", "> 2.0.0"
   spec.add_dependency "mixlib-shellout"
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"

--- a/lib/guard/kitchen.rb
+++ b/lib/guard/kitchen.rb
@@ -15,11 +15,17 @@
 #
 
 require "guard"
-require "guard/guard"
+require "guard/plugin"
 require "mixlib/shellout"
 
 module Guard
-  class Kitchen < Guard
+  class Kitchen < Plugin
+    def initialize(options = {})
+      super
+      # you can still access the watchers with options[:watchers]
+      # rest of the implementation...
+    end
+        
     def start
       ::Guard::UI.info("Guard::Kitchen is starting")
       cmd = Mixlib::ShellOut.new("kitchen create", :timeout => 10800)

--- a/lib/guard/kitchen/version.rb
+++ b/lib/guard/kitchen/version.rb
@@ -1,8 +1,8 @@
 require 'guard'
-require 'guard/guard'
+require 'guard/plugin'
 
 module Guard
-  class Kitchen < Guard
-    VERSION = "0.0.3"
+  class Kitchen < Plugin
+    VERSION = "0.0.4"
   end
 end

--- a/spec/unit/guard/kitchen_spec.rb
+++ b/spec/unit/guard/kitchen_spec.rb
@@ -1,6 +1,21 @@
 require 'spec_helper'
 require 'guard/kitchen'
 
+# Breaking change in guard 2.x for RSPEC caused by the fact
+# we didn't initialize guard's internals before Guard::Kitchen.new()
+# See https://github.com/guard/guard/issues/693
+#
+# The recommended way fix it is to install guard-compat and use that
+# instead of real guard for testing. That adds a development dependency,
+# so for now just monkey patch to stub out Guard::Plugin#initialize
+module Guard
+  class Plugin
+    def initialize(options={})
+    end
+  end
+end
+# End of Monkey Patch
+
 describe "Guard::Kitchen" do
   let(:kitchen) do
     Guard::Kitchen.new


### PR DESCRIPTION
- Extend Guard::Plugin instead of Guard::Guard
- Fix RSpecs to avoid problem with uninitialised guard internals

Guard 2.8.x deprecated the use of Guard::Guard over a year ago.
Use of guard-kitchen generates deprecation warnings.

Guard 2.9.x removed guard/guard.rb breaking anything that extends
Guard::Guard (such as guard-kitchen)
