### PR TITLE
Use Guard::Plugin to be Guard 2.0+ compliant

### DIFF
--- a/lib/guard/kitchen.rb
+++ b/lib/guard/kitchen.rb
@@ -15,11 +15,11 @@
 #
 
 require "guard"
-require "guard/guard"
+require "guard/plugin"
 require "mixlib/shellout"
 
 module Guard
-  class Kitchen < Guard
+  class Kitchen < Plugin
     def start
       ::Guard::UI.info("Guard::Kitchen is starting")
       cmd = Mixlib::ShellOut.new("kitchen create", :timeout => 10800)

--- a/lib/guard/kitchen/version.rb
+++ b/lib/guard/kitchen/version.rb
@@ -1,8 +1,8 @@
 require 'guard'
-require 'guard/guard'
+require 'guard/plugin'
 
 module Guard
-  class Kitchen < Guard
+  class Kitchen < Plugin
     VERSION = "0.0.3"
   end
 end


### PR DESCRIPTION
Referencing https://github.com/guard/guard/wiki/Upgrading-to-Guard-2.0

Without this, when I add `gem 'guard-kitchen'` to my Gemfile and then do a `bundle install`, it downloads guard v2.12.4. As you can see, as of v2.9.0, guard.rb no longer exists: https://github.com/guard/guard/tree/v2.12.4/lib/guard in the latest version of guard (previously it existed with a BIG deprecation warning: https://github.com/guard/guard/blob/v2.8.2/lib/guard/guard.rb)


```text
# Guardfile

guard :kitchen do
  watch(%r{test/.+})
  watch(%r{^recipes/(.+)\.rb$})
  watch(%r{^attributes/(.+)\.rb$})
  watch(%r{^files/(.+)})
  watch(%r{^templates/(.+)})
  watch(%r{^providers/(.+)\.rb})
  watch(%r{^resources/(.+)\.rb})
end
```

And then run `bundle exec guard` or just `guard` from the command line, I get

```
$ guard
WARN: Unresolved specs during Gem::Specification.reset:
      notiffany (~> 0.0)
WARN: Clearing out unresolved specs.
Please report a bug if this causes problems.
12:43:56 - ERROR - Could not load 'guard/kitchen' or find class Guard::Kitchen
12:43:56 - ERROR - Error is: cannot load such file -- guard/guard
12:43:56 - ERROR - /Users/smollah/.chefdk/gem/ruby/2.1.0/gems/guard-kitchen-0.0.2/lib/guard/kitchen.rb:18:in `require'
> [#] /Users/smollah/.chefdk/gem/ruby/2.1.0/gems/guard-kitchen-0.0.2/lib/guard/kitchen.rb:18:in `<top (required)>'
> [#] /Users/smollah/.chefdk/gem/ruby/2.1.0/gems/guard-2.12.4/lib/guard/plugin_util.rb:105:in `require'
> [#] /Users/smollah/.chefdk/gem/ruby/2.1.0/gems/guard-2.12.4/lib/guard/plugin_util.rb:105:in `rescue in plugin_class'
> [#] /Users/smollah/.chefdk/gem/ruby/2.1.0/gems/guard-2.12.4/lib/guard/plugin_util.rb:97:in `plugin_class'
> [#] /Users/smollah/.chefdk/gem/ruby/2.1.0/gems/guard-2.12.4/lib/guard/plugin_util.rb:56:in `initialize_plugin'
> [#] /Users/smollah/.chefdk/gem/ruby/2.1.0/gems/guard-2.12.4/lib/guard/internals/plugins.rb:26:in `add'
> [#] /Users/smollah/.chefdk/gem/ruby/2.1.0/gems/guard-2.12.4/lib/guard/dsl.rb:185:in `block in guard'
> [#] /Users/smollah/.chefdk/gem/ruby/2.1.0/gems/guard-2.12.4/lib/guard/dsl.rb:182:in `each'
> [#] /Users/smollah/.chefdk/gem/ruby/2.1.0/gems/guard-2.12.4/lib/guard/dsl.rb:182:in `guard'
> [#] /Users/smollah/workspace/chef-fast-ruby/Guardfile:1:in `evaluate'
> [#] /Users/smollah/.chefdk/gem/ruby/2.1.0/gems/guard-2.12.4/lib/guard/dsl.rb:377:in `instance_eval'
> [#] /Users/smollah/.chefdk/gem/ruby/2.1.0/gems/guard-2.12.4/lib/guard/dsl.rb:377:in `evaluate'
> [#] /Users/smollah/.chefdk/gem/ruby/2.1.0/gems/guard-2.12.4/lib/guard/guardfile/evaluator.rb:90:in `evaluate'
> [#] /Users/smollah/.chefdk/gem/ruby/2.1.0/gems/guard-2.12.4/lib/guard.rb:134:in `_evaluate'
> [#] /Users/smollah/.chefdk/gem/ruby/2.1.0/gems/guard-2.12.4/lib/guard.rb:49:in `setup'
> [#] /Users/smollah/.chefdk/gem/ruby/2.1.0/gems/guard-2.12.4/lib/guard/commander.rb:32:in `start'
> [#] /Users/smollah/.chefdk/gem/ruby/2.1.0/gems/guard-2.12.4/lib/guard/cli/environments/valid.rb:16:in `start_guard'
> [#] /Users/smollah/.chefdk/gem/ruby/2.1.0/gems/guard-2.12.4/lib/guard/cli.rb:113:in `start'
> [#] /opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor/command.rb:27:in `run'
> [#] /opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor/invocation.rb:126:in `invoke_command'
> [#] /opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor.rb:359:in `dispatch'
> [#] /opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor/base.rb:440:in `start'
> [#] /Users/smollah/.chefdk/gem/ruby/2.1.0/gems/guard-2.12.4/lib/guard/aruba_adapter.rb:32:in `execute'
> [#] /Users/smollah/.chefdk/gem/ruby/2.1.0/gems/guard-2.12.4/lib/guard/aruba_adapter.rb:19:in `execute!'
> [#] /Users/smollah/.chefdk/gem/ruby/2.1.0/gems/guard-2.12.4/bin/_guard-core:11:in `<main>'
12:43:57 - ERROR - Invalid Guardfile, original error is:
> [#]
> [#] Could not load class: "Kitchen",
> [#] backtrace:
> [#]   (dsl)> $GEM_PATH[0]/gems/guard-2.12.4/lib/guard/plugin_util.rb:57:in `initialize_plugin'
> [#]   (dsl)> $GEM_PATH[0]/gems/guard-2.12.4/lib/guard/internals/plugins.rb:26:in `add'
> [#]   (dsl)> $GEM_PATH[0]/gems/guard-2.12.4/lib/guard/dsl.rb:185:in `block in guard'
> [#]   (dsl)> $GEM_PATH[0]/gems/guard-2.12.4/lib/guard/dsl.rb:182:in `each'
> [#]   (dsl)> $GEM_PATH[0]/gems/guard-2.12.4/lib/guard/dsl.rb:182:in `guard'
> [#]   (dsl)> ./Guardfile:1:in `evaluate'
> [#]   (dsl)> $GEM_PATH[0]/gems/guard-2.12.4/lib/guard/dsl.rb:377:in `instance_eval'
> [#]   (dsl)> $GEM_PATH[0]/gems/guard-2.12.4/lib/guard/dsl.rb:377:in `evaluate'
> [#]   (dsl)> $GEM_PATH[0]/gems/guard-2.12.4/lib/guard/guardfile/evaluator.rb:90:in `evaluate'
> [#]   (dsl)> $GEM_PATH[0]/gems/guard-2.12.4/lib/guard.rb:134:in `_evaluate'
> [#]   (dsl)> $GEM_PATH[0]/gems/guard-2.12.4/lib/guard.rb:49:in `setup'
> [#]   (dsl)> $GEM_PATH[0]/gems/guard-2.12.4/lib/guard/commander.rb:32:in `start'
> [#]   (dsl)> $GEM_PATH[0]/gems/guard-2.12.4/lib/guard/cli/environments/valid.rb:16:in `start_guard'
> [#]   (dsl)> $GEM_PATH[0]/gems/guard-2.12.4/lib/guard/cli.rb:113:in `start'
> [#]   (dsl)> $GEM_PATH[1]/gems/thor-0.19.1/lib/thor/command.rb:27:in `run'
> [#]   (dsl)> $GEM_PATH[1]/gems/thor-0.19.1/lib/thor/invocation.rb:126:in `invoke_command'
> [#]   (dsl)> $GEM_PATH[1]/gems/thor-0.19.1/lib/thor.rb:359:in `dispatch'
> [#]   (dsl)> $GEM_PATH[1]/gems/thor-0.19.1/lib/thor/base.rb:440:in `start'
> [#]   (dsl)> $GEM_PATH[0]/gems/guard-2.12.4/lib/guard/aruba_adapter.rb:32:in `execute'
> [#]   (dsl)> $GEM_PATH[0]/gems/guard-2.12.4/lib/guard/aruba_adapter.rb:19:in `execute!'
> [#]   (dsl)> $GEM_PATH[0]/gems/guard-2.12.4/bin/_guard-core:11:in `<main>'
```
